### PR TITLE
Fixes image compression on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.3.0] - 2020.01.24
+
+* merge pull request from Miguel Ruivo @miguelpruivo to fix Android image compression
+
 ## [1.3.0] - 2019.10.04
 
 * merge pull request from Miguel Ruivo @miguelpruivo to fix iOS 13 not working

--- a/android/src/main/java/com/example/mediaspicker/MediasPickerPlugin.java
+++ b/android/src/main/java/com/example/mediaspicker/MediasPickerPlugin.java
@@ -166,7 +166,7 @@ public class MediasPickerPlugin implements MethodCallHandler, ActivityResultList
 		Bitmap scaledBitmap = null;
 		BitmapFactory.Options options = new BitmapFactory.Options();
 		options.inJustDecodeBounds = true;
-
+		BitmapFactory.decodeFile(new File(filename).getAbsolutePath(), options);
 		int actualHeight = options.outHeight;
 		int actualWidth = options.outWidth;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_picker
 description: Flutter plugin to get pictures and videos from the device. It allows you to select one or more images from gallery or camera, without needing to switch provider.
-version: 1.3.0
+version: 1.3.1
 author: Duarte Silveira <dsilveira@gmx.net>
 homepage: https://github.com/d-silveira/flutter_media_picker
 


### PR DESCRIPTION
Fixes an issue that was resulting in an exception being thrown when compressing images on Android because `actualHeight` and `actualWidth` were missing.